### PR TITLE
CR-41180: Fix workflow link reported to Codefresh

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -74,7 +74,9 @@ jobs:
           CF_API_KEY: ${{ secrets.CF3_API }}
           CF_HOST_URL: https://g.codefresh.io
           WORKFLOW_NAME: ${{ github.workflow }}
-          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/${{ github.workflow }}
+          # The workflows/ URL path takes the workflow FILE name - github.workflow
+          # expands to the workflow's display name, which breaks the link.
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/docker-ci.yaml
           LOGS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
`WORKFLOW_URL` used `github.workflow` (the display name) where the Actions URL needs the workflow file name. Re-running the pipeline also refreshes the link on the existing `green` image entity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)